### PR TITLE
Replace function that retruns string with var to clean up dot accessor

### DIFF
--- a/Source/RequestBuilder.swift
+++ b/Source/RequestBuilder.swift
@@ -57,7 +57,7 @@ public enum RequestEncoding {
     /// The JSON text/html Accept/Content-Type encoding.
     case textHTML
 
-    var headerString: String {
+    fileprivate var headerString: String {
         switch self {
 
         case .json:

--- a/Source/RequestBuilder.swift
+++ b/Source/RequestBuilder.swift
@@ -57,7 +57,7 @@ public enum RequestEncoding {
     /// The JSON text/html Accept/Content-Type encoding.
     case textHTML
 
-    func headerString() -> String {
+    var headerString: String {
         switch self {
 
         case .json:
@@ -109,8 +109,8 @@ public enum RequestBuilder {
             request.httpBody = jsonData
         }
 
-        request.addValue(acceptEncoding.headerString(), forHTTPHeaderField: "Accept")
-        request.addValue(contentType.headerString(), forHTTPHeaderField: "Content-Type")
+        request.addValue(acceptEncoding.headerString, forHTTPHeaderField: "Accept")
+        request.addValue(contentType.headerString, forHTTPHeaderField: "Content-Type")
 
         request.httpShouldHandleCookies = false
 


### PR DESCRIPTION
Replace the `headerString()` function with computed property that returns a `String`